### PR TITLE
fixed password bug

### DIFF
--- a/tests/Feature/GeneralTest.php
+++ b/tests/Feature/GeneralTest.php
@@ -111,7 +111,7 @@ class GeneralTest extends TestCase
         ];
 
         $invalidPassword = '12345678';
-        $validPassword = 'a12345678';
+        $validPassword = 'aA12345678';
 
         $this->post('/register', $user + [
                 'password'              => $invalidPassword,


### PR DESCRIPTION
in `GeneralTest.php:114` the valid password is not valid because it doesn't contain at least one uppercase letter :
```php
$validPassword = 'a12345678'; //no uppercase letters
```
this will make the test fail wrongfully at `GeneralTest.php:127`:
```php
 $this->assertDatabaseHas('users', $user); //this test will fail
```
```php
    public function test_password_at_least_one_uppercase_lowercase_letter()
    {
        $user = [
            'name'  => 'New name',
            'email' => 'new@email.com',
        ];

        $invalidPassword = '12345678';
        $validPassword = 'a12345678';//no uppercase letters

        $this->post('/register', $user + [
                'password'              => $invalidPassword,
                'password_confirmation' => $invalidPassword,
            ]);
        $this->assertDatabaseMissing('users', $user);

        $response = $this->post('/register', $user + [
                'password'              => $validPassword,
                'password_confirmation' => $validPassword,
            ]);
        $this->assertDatabaseHas('users', $user); //this test will fail
    }

```